### PR TITLE
Add marker file so the bootstrapper is only run every 24 hours

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,4 @@ if ! test -f .paket/paket.bootstrapper.run || find .paket/paket.bootstrapper.run
 fi
 
 $MONO .paket/paket.exe restore
-$MONO packages/FAKE/tools/FAKE.exe
+$MONO packages/FAKE/tools/FAKE.exe $@

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,11 @@ else
   MONO=""
 fi
 
-$MONO .paket/paket.bootstrapper.exe
+# Only run bootstrapper if we haven't done so in the last 24 hours, this keeps builds fast.
+if ! test -f .paket/paket.bootstrapper.run || find .paket/paket.bootstrapper.run -type f -mtime +1 | grep -q paket.bootstrapper.run; then
+    $MONO .paket/paket.bootstrapper.exe
+    touch .paket/paket.bootstrapper.run
+fi
+
 $MONO .paket/paket.exe restore
 $MONO packages/FAKE/tools/FAKE.exe


### PR DESCRIPTION
@moodmosaic would you mind checking if this new `build.sh` works as expected on Windows?

The general idea is that the bootstrapper is only run if it's been more than 24 hours since the last run. Would be nice to know if the `COMSPEC` trick works as well.