### PR TITLE
Make build.sh easier to maintain,

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,16 @@
 #!/bin/sh -eu
 
 if [ -z "${COMSPEC-}" ]; then
-  MONO="mono"
+  run="mono"
 else
-  MONO=""
+  run=""
 fi
 
 # Only run bootstrapper if we haven't done so in the last 24 hours, this keeps builds fast.
 if ! test -f .paket/paket.bootstrapper.run || find .paket/paket.bootstrapper.run -type f -mtime +1 | grep -q paket.bootstrapper.run; then
-    $MONO .paket/paket.bootstrapper.exe
+    $run .paket/paket.bootstrapper.exe
     touch .paket/paket.bootstrapper.run
 fi
 
-$MONO .paket/paket.exe restore
-$MONO packages/FAKE/tools/FAKE.exe $@
+$run .paket/paket.exe restore
+$run packages/FAKE/tools/FAKE.exe $@


### PR DESCRIPTION
in order to make it clear that the build isn't always triggered via Mono.