### PR TITLE
Remove #light directive,

### DIFF
--- a/Jack/Gen.fs
+++ b/Jack/Gen.fs
@@ -1,5 +1,4 @@
-﻿#light
-namespace Jack
+﻿namespace Jack
 
 open FSharpx.Collections
 

--- a/Jack/Property.fs
+++ b/Jack/Property.fs
@@ -1,5 +1,4 @@
-﻿#light
-namespace Jack
+﻿namespace Jack
 
 open FSharpx.Collections
 

--- a/Jack/Random.fs
+++ b/Jack/Random.fs
@@ -1,5 +1,4 @@
-﻿#light
-namespace Jack
+﻿namespace Jack
 
 open FsControl.Operators
 

--- a/Jack/Seed.fs
+++ b/Jack/Seed.fs
@@ -9,7 +9,6 @@
 //    Comm ACM, 31(6), Jun 1988, pp742-749.
 //
 
-#light
 namespace Jack
 
 /// Splittable random number generator.

--- a/Jack/Shrink.fs
+++ b/Jack/Shrink.fs
@@ -1,5 +1,4 @@
-﻿#light
-namespace Jack
+﻿namespace Jack
 
 open FSharpx.Collections
 

--- a/Jack/Tree.fs
+++ b/Jack/Tree.fs
@@ -1,5 +1,4 @@
-﻿#light
-namespace Jack
+﻿namespace Jack
 
 open FSharpx.Collections
 


### PR DESCRIPTION
since the default syntax is the lightweight syntax.

See also: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/verbose-syntax