### PR TITLE
Add an example-based test for Shrink.removes

### DIFF
--- a/Jack.Tests/App.config
+++ b/Jack.Tests/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <Paket>True</Paket>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Jack.Tests/Jack.Tests.fsproj
+++ b/Jack.Tests/Jack.Tests.fsproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Library1.fs" />
+    <Compile Include="ShrinkTests.fs" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <ItemGroup>

--- a/Jack.Tests/Jack.Tests.fsproj
+++ b/Jack.Tests/Jack.Tests.fsproj
@@ -46,6 +46,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ShrinkTests.fs" />
     <None Include="Script.fsx" />
+    <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jack\Jack.fsproj">
@@ -95,6 +96,17 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="FSharpx.Collections">
+          <HintPath>..\packages\FSharpx.Collections\lib\net40\FSharpx.Collections.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
       <ItemGroup>

--- a/Jack.Tests/Library1.fs
+++ b/Jack.Tests/Library1.fs
@@ -1,4 +1,0 @@
-﻿namespace Jack.Tests
-
-type Class1() = 
-    member this.X = "F#"

--- a/Jack.Tests/ShrinkTests.fs
+++ b/Jack.Tests/ShrinkTests.fs
@@ -1,1 +1,17 @@
 ﻿module Jack.Tests.ShrinkTests
+
+open FSharpx.Collections
+open Jack
+open Swensen.Unquote
+open Xunit
+
+[<Fact>]
+let ``removes permutes a list by removing 'k' consecutive elements from it``() =
+    let actual = Shrink.removes 2 [ 1; 2; 3; 4; 5; 6 ]
+
+    let expected =
+        LazyList.ofList [ [ 3; 4; 5; 6 ]
+                          [ 1; 2; 5; 6 ]
+                          [ 1; 2; 3; 4 ] ]
+    // http://stackoverflow.com/a/17101488
+    test <@ Seq.fold (&&) true (Seq.zip expected actual |> Seq.map (fun (a, b) -> a = b)) @>

--- a/Jack.Tests/ShrinkTests.fs
+++ b/Jack.Tests/ShrinkTests.fs
@@ -1,0 +1,1 @@
+﻿module Jack.Tests.ShrinkTests

--- a/Jack.Tests/paket.references
+++ b/Jack.Tests/paket.references
@@ -1,3 +1,5 @@
 xunit.runner.console
 xunit.core
 Unquote
+
+FSharpx.Collections

--- a/Jack/Shrink.fs
+++ b/Jack/Shrink.fs
@@ -23,7 +23,7 @@ module LazyList =
 module Shrink =
     /// Permutes a list by removing 'k' consecutive elements from it:
     ///
-    /// <c>removes 2 [1,2,3,4,5,6] = [[3,4,5,6],[1,2,5,6],[1,2,3,4]]</c>
+    /// <c>removes 2 [1;2;3;4;5;6] = [[3;4;5;6];[1;2;5;6];[1;2;3;4]]</c>
     ///
     let removes (k0 : int) (xs0 : List<'a>) : LazyList<List<'a>> =
         let rec loop (k : int) (n : int) (xs : List<'a>) : LazyList<List<'a>> =

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,3 +1,4 @@
+redirects: on
 source https://www.nuget.org/api/v2/
 
 nuget FAKE 4.41.1

--- a/paket.lock
+++ b/paket.lock
@@ -1,3 +1,4 @@
+REDIRECTS: ON
 NUGET
   remote: https://www.nuget.org/api/v2
     FAKE (4.41.1)


### PR DESCRIPTION
This pull request adds a test module for writing example-based tests, as well as property-based tests, for the functions in the `Shrink` module.

Adding the very first test required setting ['redirects: on' in Paket](https://fsprojects.github.io/Paket/dependencies-file.html#Redirects-option), as well as referencing FSharpx.Collections.
