### PR TITLE
Add combinators for shrinking, choice, numbers, strings, collections

### DIFF
--- a/Jack/Jack.fsproj
+++ b/Jack/Jack.fsproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Numeric.fs" />
     <Compile Include="Seed.fs" />
     <Compile Include="Tree.fs" />
     <Compile Include="Random.fs" />

--- a/Jack/Numeric.fs
+++ b/Jack/Numeric.fs
@@ -1,0 +1,24 @@
+﻿namespace Jack
+
+//
+// The handful of ad-hoc polymorphic things we need from FsControl.
+//
+
+open FsControl
+
+module Numeric =
+    /// Returns the smallest possible value.
+    let inline minValue () : ^a =
+        MinValue.Invoke ()
+
+    /// Returns the largest possible value.
+    let inline maxValue () : ^a =
+        MaxValue.Invoke ()
+
+    /// Converts from a BigInt to the inferred destination type.
+    let inline fromBigInt (x : bigint) : ^a =
+        FromBigInt.Invoke x
+
+    /// Converts to a BigInt.
+    let inline toBigInt (x : ^a) : bigint =
+        ToBigInt.Invoke x

--- a/Jack/Property.fs
+++ b/Jack/Property.fs
@@ -122,9 +122,9 @@ module Property =
         check' 100 p
 
 [<AutoOpen>]
-module ForAll =
+module ForAllBuilder =
     type Builder internal () =
-        member __.ReturnFrom(b : bool) : Property =
+        member __.Return(b : bool) : Property =
             Property.ofBool b
         member __.ReturnFrom(p : Property) : Property =
             p

--- a/Jack/Random.fs
+++ b/Jack/Random.fs
@@ -1,6 +1,6 @@
 ﻿namespace Jack
 
-open FsControl.Operators
+open Jack.Numeric
 
 /// Tests are parameterized by the `Size` of the randomly-generated data,
 /// the meaning of which depends on the particular generator used.
@@ -11,11 +11,16 @@ type Random<'a> =
     | Random of (Seed -> Size -> 'a)
 
 module Random =
-    let private unsafeRun  (seed : Seed) (size : Size) (Random r : Random<'a>) : 'a =
+    let private unsafeRun (seed : Seed) (size : Size) (Random r : Random<'a>) : 'a =
         r seed size
 
     let run (seed : Seed) (size : Size) (r : Random<'a>) : 'a =
         unsafeRun seed (max 1 size) r
+
+    let delay (f : unit -> Random<'a>) : Random<'a> =
+        let g = lazy (f ())
+        Random <| fun seed size ->
+            unsafeRun seed size (g.Force())
 
     let constant (x : 'a) : Random<'a> =
         Random <| fun _ _ ->
@@ -46,6 +51,16 @@ module Random =
                     loop seed2 (k - 1) (x :: acc)
             loop seed0 times []
 
+    type Builder internal () =
+        member __.Return(x : 'a) : Random<'a> =
+            constant x
+        member __.ReturnFrom(m : Random<'a>) : Random<'a> =
+            m
+        member __.Bind(m : Random<'a>, k : 'a -> Random<'b>) : Random<'b> =
+            bind m k
+
+    let private random = Builder ()
+
     /// Used to construct generators that depend on the size parameter.
     let sized (f : Size -> Random<'a>) : Random<'a> =
         Random <| fun seed size ->
@@ -58,7 +73,41 @@ module Random =
           run seed newSize r
 
     /// Generates a random element in the given inclusive range.
-    let inline choose (lo : ^a) (hi : ^a) : Random<'a> =
+    let inline range (lo : ^a) (hi : ^a) : Random<'a> =
         Random <| fun seed _ ->
             let x, _ = Seed.nextBigInt (toBigInt lo) (toBigInt hi) seed
             fromBigInt x
+
+    /// Generates a random number in the given inclusive range, but smaller
+    /// numbers are generated more often than bigger ones.
+    let inline sizedRange (lo0 : ^a) (hi0 : ^a) : Random<'a> =
+        sized <| fun size ->
+            let rec bits n =
+                if n = 0I then
+                    0
+                else
+                    1 + bits (n / 2I)
+
+            let lo_big = toBigInt lo0
+            let hi_big = toBigInt hi0
+
+            let b = 40 |> max (bits lo_big) |> max (bits hi_big)
+            let k = pown 2I ((size * b) / 80)
+            let lo = max lo_big (-k)
+            let hi = min hi_big k
+
+            map fromBigInt (range lo hi)
+
+    /// Generates a random floating point number.
+    let sizedDouble : Random<double> =
+        sized <| fun size0 -> random {
+            let size = bigint size0
+            let precision = 9999999999999I
+            let! x = range ((-size) * precision) (size * precision)
+            let! y = range 1I precision
+            return (double x / double y)
+        }
+
+[<AutoOpen>]
+module RandomBuilder =
+    let random = Random.Builder ()

--- a/Jack/Script.fsx
+++ b/Jack/Script.fsx
@@ -1,6 +1,7 @@
 ﻿#r "../packages/FSharpx.Collections/lib/net40/FSharpx.Collections.dll"
 #r "../packages/FsControl/lib/net40/FsControl.dll"
 
+#load "Numeric.fs"
 #load "Seed.fs"
 #load "Tree.fs"
 #load "Shrink.fs"
@@ -10,15 +11,68 @@
 
 open Jack
 
+//
+// Combinators
+//
+
 Property.check <| forAll {
-    let! x = Gen.choose 1 100
-    let! y = Gen.elements [ "a"; "b"; "c"; "d" ]
-    return! x < 50 || y = "a"
+    let! x = Gen.range 1 100
+    let! ys = Gen.item ["a"; "b"; "c"; "d"] |> Gen.seq1
+    return x < 50 || Seq.length ys <= 3 || Seq.contains "a" ys
 }
+
+Property.check <| forAll {
+    let! xs = Gen.string
+    return String.length xs <= 5
+}
+
+//
+// Hutton's Razor
+//
+
+type Exp =
+  | Lit of int
+  | Add of Exp * Exp
+
+let rec evalExp = function
+    | Lit x ->
+        x
+    | Add (x, y) ->
+        evalExp x + evalExp y
+
+let shrinkExp = function
+    | Lit _ ->
+        []
+    | Add (x, y) ->
+        [x; y]
+
+#nowarn "40"
+let rec genExp =
+    Gen.delay <| fun _ ->
+    Gen.shrink shrinkExp <|
+    Gen.choiceRec [
+        Lit <!> Gen.int
+    ] [
+        Add <!> Gen.zip genExp genExp
+    ]
+
+Property.check <| forAll {
+    let! x = genExp
+    match x with
+    | Add (Add _, Add _) when evalExp x > 100 ->
+        return false
+    | _ ->
+        return true
+}
+
+//
+// Printing Samples
+//
 
 Gen.printSample <| gen {
-    let! x = Gen.choose 0 10
-    let! y = Gen.elements [ "x"; "y"; "z"; "w" ]
-    return sprintf "%A + %s" x y
+    let! x = Gen.range 0 10
+    let! y = Gen.item [ "x"; "y"; "z"; "w" ]
+    let! z = Gen.double
+    let! w = Gen.string' Gen.alphaNum
+    return sprintf "%A + %s + %f + %s" x y z w
 }
-


### PR DESCRIPTION
I decided to diverge from some of the traditional names for things to try an make them fit better into an F# style.

Haskell QuickCheck -> F# Jack
`elements` -> `Gen.item`
`choose` -> `Gen.range`
`oneof` -> `Gen.choice`
`listOf` -> `Gen.list` / `Gen.array` / `Gen.seq`

@moodmosaic Would be interested to know what you think.