### PR TITLE
Conditional and Lazy Properties

### DIFF
--- a/Jack/Script.fsx
+++ b/Jack/Script.fsx
@@ -78,6 +78,22 @@ Property.check <| forAll {
 }
 
 //
+// Conditional Properties
+//
+
+fun (x, y) -> (x > 0 && y > 0) ==> (x * y > 0)
+|> Property.forAll (Gen.zip Gen.int Gen.int)
+|> Property.check
+
+//
+// Lazy Properties
+//
+
+fun n -> n <> 0 ==> lazy (1 / n = 1 / n)
+|> Property.forAll Gen.int
+|> Property.check
+
+//
 // Printing Samples
 //
 


### PR DESCRIPTION
Implemented as in QuickCheck 1.2.0.1, and as described in the [manual](http://www.cse.chalmers.se/~rjmh/QuickCheck/manual.html
). The important thing here is that even though properties may take the form

```
<condition> ==> <property>
```

F# has strict semantics, and so the use of a lazy computation can be required in cases we shouldn't evaluate the property at the right of the condition.

For example, the following property isn't checked correctly without using a `lazy` computation:

```f#
fun n -> n <> 0 ==> (1 / n = 1 / n)
|> Property.forAll Gen.int
|> Property.check

System.DivideByZeroException: Attempted to divide by zero.
>    at FSI_0045.it@92-64.Invoke(Int32 n) in ..
Stopped due to error
```

Instead, we need to tell Jack to *not* evaluate the computation immediately and instead evaluate it only when the result is needed:

```f#
fun n -> n <> 0 ==> lazy (1 / n = 1 / n)
|> Property.forAll Gen.int
|> Property.check

+++ OK, passed 100 tests.
val it : bool = true
>
```