### PR TITLE
Do we care about making Shrink.double more generic?

### DIFF
--- a/Jack/Gen.fs
+++ b/Jack/Gen.fs
@@ -403,7 +403,7 @@ module Gen =
 
     /// Generates a random 64-bit floating point number.
     let double : Gen<double> =
-        create Shrink.double Random.sizedDouble
+        create Shrink.number Random.sizedDouble
 
     /// Generates a random 64-bit floating point number.
     let float : Gen<float> =

--- a/Jack/Shrink.fs
+++ b/Jack/Shrink.fs
@@ -108,16 +108,15 @@ module Shrink =
             LazyList.consNub destination <|
             LazyList.map (fun y -> x - y) (halves diff)
 
-    /// Shrink a floating point number.
-    let double (x : double) : LazyList<double> =
+    /// Shrink a number.
+    let inline number x : LazyList<'a> =
         let positive =
-            if x < 0.0 then
+            if x < LanguagePrimitives.GenericZero then
                 LazyList.singleton (-x)
             else
                 LazyList.empty
 
         let integrals =
-            towards 0I (bigint x)
-            |> LazyList.map double
+            towards LanguagePrimitives.GenericZero x
 
         LazyList.append positive integrals


### PR DESCRIPTION
If so, this pull request turns `Shrink.double` into a generic `Shrink.number` function:

```f#
val number : x:'a -> LazyList<'a>
	(requires member get_Zero
		  and member ( ~- )
		  and member ( - )
		  and member ( / )
		  and member ( + )
		  and member get_One
		  and comparison)

// > Shrink.number 10.m;;
// val it : FSharpx.Collections.LazyList<decimal> =
//   seq [0M; 5M; 7.5M; 8.75M; ...]

// > Shrink.number 10.0;;
// val it : FSharpx.Collections.LazyList<float> =
//	 seq [0.0; 5.0; 7.5; 8.75; ...]

// > Shrink.number 10s;;
// val it : FSharpx.Collections.LazyList<int16> =
//   seq [0s; 5s; 8s; 9s]

// > Shrink.number 10L;;
// val it : FSharpx.Collections.LazyList<int64> = 
//   seq [0L; 5L; 8L; 9L]

// > Shrink.number 10;;
// val it : FSharpx.Collections.LazyList<int> = 
//   seq [0; 5; 8; 9]
```