### PR TITLE
Property.check now throws exceptions for better test runner integration

### DIFF
--- a/Jack.Tests/Jack.Tests.fsproj
+++ b/Jack.Tests/Jack.Tests.fsproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ShrinkTests.fs" />
+    <Compile Include="MinimalTests.fs" />
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
@@ -95,6 +96,17 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="FsControl">
+          <HintPath>..\packages\FsControl\lib\net40\FsControl.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>

--- a/Jack.Tests/MinimalTests.fs
+++ b/Jack.Tests/MinimalTests.fs
@@ -1,0 +1,90 @@
+module Jack.Tests.MinimalTests
+
+open FSharpx.Collections
+open Jack
+open Swensen.Unquote
+open Xunit
+
+type Exp =
+    | Lit of int
+    | Var of string
+    | Lam of string * Exp
+    | App of Exp * Exp
+
+let shrinkExp : Exp -> List<Exp> = function
+    | Lam (_, x) ->
+        [x]
+    | App (x, y) ->
+        [x; y]
+    | _ ->
+        []
+
+let genName =
+    Gen.item ["a"; "b"; "c"; "d"]
+
+#nowarn "40"
+let rec genExp : Gen<Exp> =
+    Gen.delay <| fun _ ->
+    Gen.shrink shrinkExp <| // comment this out to see the property fail
+    Gen.choiceRec [
+        Lit <!> Gen.range 0 10
+        Var <!> genName
+    ] [
+        Lam <!> Gen.zip genName genExp
+        App <!> Gen.zip genExp genExp
+    ]
+
+// a vaguely interesting predicate which checks that a certain sub-expression
+// cannot be found anywhere in the expression.
+let rec noAppLit10 : Exp -> bool = function
+    | Lit _ ->
+        true
+    | Var _ ->
+        true
+    | Lam (_, x) ->
+        noAppLit10 x
+    | App (_, Lit 10) ->
+        false
+    | App (x, y) ->
+        noAppLit10 x &&
+        noAppLit10 y
+
+// FIXME does this exist in the core libraries already?
+let (<|>) x y =
+    match x with
+    | None ->
+        y
+    | Some _ ->
+        x
+
+let rec tryFindSmallest (p : 'a -> bool) (Node (x, xs) : Tree<'a>) : 'a option =
+    if p x then
+        None
+    else
+        Seq.tryPick (tryFindSmallest p) xs <|> Some x
+
+// FIXME This test takes quite some time to run, it would be good to profile
+// FIXME this and find out where the hotspots are. I have a much more complex
+// FIXME version of the same test in Haskell and it finishes in a few seconds,
+// FIXME even in GHCi (the interpreter).
+[<Fact>]
+let ``greedy traversal with a predicate yields the perfect minimal shrink``() =
+    Property.check <| property {
+        let! xs = Gen.mapTree Tree.duplicate genExp |> Gen.resize 20
+        match tryFindSmallest noAppLit10 xs with
+        | None ->
+            return true
+        | Some (App (Lit 0, Lit 10)) ->
+            return true
+        | Some x ->
+            return! property {
+                counterexample ""
+                counterexample "Greedy traversal with predicate did not yield the minimal shrink."
+                counterexample ""
+                counterexample "=== Minimal ==="
+                counterexample (sprintf "%A" (App (Lit 0, Lit 10)))
+                counterexample "=== Actual ==="
+                counterexample (sprintf "%A" x)
+                return false
+            }
+    }

--- a/Jack.Tests/paket.references
+++ b/Jack.Tests/paket.references
@@ -2,4 +2,5 @@ xunit.runner.console
 xunit.core
 Unquote
 
+FsControl
 FSharpx.Collections

--- a/Jack/Gen.fs
+++ b/Jack/Gen.fs
@@ -17,6 +17,9 @@ module Gen =
     let delay (f : unit -> Gen<'a>) : Gen<'a> =
         Random.delay (toRandom << f) |> ofRandom
 
+    let tryWith (m : Gen<'a>) (k : exn -> Gen<'a>) : Gen<'a> =
+        Random.tryWith (toRandom m) (toRandom << k) |> ofRandom
+
     let create (shrink : 'a -> LazyList<'a>) (random : Random<'a>) : Gen<'a> =
         Random.map (Tree.unfold id shrink) random |> ofRandom
 

--- a/Jack/Jack.fsproj
+++ b/Jack/Jack.fsproj
@@ -72,17 +72,6 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
-        <Reference Include="FSharpPlus">
-          <HintPath>..\packages\FSharpPlus\lib\net40\FSharpPlus.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
-      <ItemGroup>
         <Reference Include="FSharpx.Collections">
           <HintPath>..\packages\FSharpx.Collections\lib\net40\FSharpx.Collections.dll</HintPath>
           <Private>True</Private>

--- a/Jack/Property.fs
+++ b/Jack/Property.fs
@@ -2,8 +2,8 @@
 
 open FSharpx.Collections
 
-type Report =
-    | Report of List<string>
+type Journal =
+    | Journal of List<string>
 
 type Result<'a> =
     | Failure
@@ -11,7 +11,22 @@ type Result<'a> =
     | Success of 'a
 
 type Property<'a> =
-    | Property of Gen<Report * Result<'a>>
+    | Property of Gen<Journal * Result<'a>>
+
+[<Measure>] type tests
+[<Measure>] type discards
+[<Measure>] type shrinks
+
+type Status =
+    | Failed of int<shrinks> * Journal
+    | GaveUp
+    | OK
+
+type Report = {
+    tests : int<tests>
+    discards : int<discards>
+    status : Status
+}
 
 [<AutoOpen>]
 module private Tuple =
@@ -20,6 +35,26 @@ module private Tuple =
 
     let second (f : 'b -> 'c) (x : 'a, y : 'b) : 'a * 'c =
         x, f y
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Journal =
+    let ofList (xs : List<string>) : Journal =
+        Journal xs
+
+    let toList (Journal xs : Journal) : List<string> =
+        xs
+
+    let empty : Journal =
+        List.empty |> ofList
+
+    let map (f : List<string> -> List<string>) (xs : Journal) : Journal =
+        toList xs |> f |> ofList
+
+    let addFailure (msg : string) (x : Journal) : Journal =
+        map (List.cons msg) x
+
+    let append (xs : Journal) (ys : Journal) : Journal =
+        toList xs @ toList ys |> ofList
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Result =
@@ -53,37 +88,132 @@ module Result =
         | Success _ ->
             false
 
+[<AutoOpen>]
+module private Pretty =
+    open System.Text
+
+    let private renderTests : int<tests> -> string = function
+        | 1<tests> ->
+            "1 test"
+        | n ->
+            sprintf "%d tests" n
+
+    let private renderDiscards : int<discards> -> string = function
+        | 1<discards> ->
+            "1 discard"
+        | n ->
+            sprintf "%d discards" n
+
+    let private renderAndDiscards : int<discards> -> string = function
+        | 0<discards> ->
+            ""
+        | 1<discards> ->
+            " and 1 discard"
+        | n ->
+            sprintf " and %d discards" n
+
+    let private renderAndShrinks : int<shrinks> -> string = function
+        | 0<shrinks> ->
+            ""
+        | 1<shrinks> ->
+            " and 1 shrink"
+        | n ->
+            sprintf " and %d shrinks" n
+
+    let private append (sb : StringBuilder) (msg : string) : unit =
+        sb.AppendLine msg |> ignore
+
+    let renderOK (tests : int<tests>) : string =
+        sprintf "+++ OK, passed %s." (renderTests tests)
+
+    let renderGaveUp (tests : int<tests>) (discards : int<discards>) : string =
+        sprintf "*** Gave up after %s, passed %s."
+            (renderDiscards discards)
+            (renderTests tests)
+
+    let renderFailed
+            (tests : int<tests>)
+            (discards : int<discards>)
+            (shrinks : int<shrinks>)
+            (journal : Journal) : string =
+        let sb = StringBuilder ()
+
+        sprintf "*** Failed! Falsifiable (after %s%s%s):"
+            (renderTests tests)
+            (renderAndShrinks shrinks)
+            (renderAndDiscards discards)
+            |> append sb
+
+        List.iter (append sb) (Journal.toList journal)
+
+        sb.ToString(0, sb.Length - 1) // exclude extra newline
+
+[<AbstractClass>]
+type JackException (message : string) =
+    inherit System.Exception (message)
+
+type GaveUpException (tests : int<tests>, discards : int<discards>) =
+    inherit JackException (renderGaveUp tests discards)
+
+    member __.Tests =
+        tests
+
+type FailedException (tests : int<tests>, discards : int<discards>, shrinks : int<shrinks>, journal : Journal) =
+    inherit JackException (renderFailed tests discards shrinks journal)
+
+    member __.Tests =
+        tests
+
+    member __.Discards =
+        discards
+
+    member __.Shrinks =
+        shrinks
+
+    member __.Journal =
+        journal
+
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Report =
-    let ofList (xs : List<string>) : Report =
-        Report xs
+    open Pretty
 
-    let toList (Report xs : Report) : List<string> =
-        xs
+    let render (report : Report) : string =
+        match report.status with
+        | OK ->
+            renderOK report.tests
+        | GaveUp ->
+            renderGaveUp report.tests report.discards
+        | Failed (shrinks, journal) ->
+            renderFailed report.tests report.discards shrinks journal
 
-    let empty : Report =
-        List.empty |> ofList
-
-    let map (f : List<string> -> List<string>) (xs : Report) : Report =
-        toList xs |> f |> ofList
-
-    let addFailure (msg : string) (x : Report) : Report =
-        map (List.cons msg) x
-
-    let append (xs : Report) (ys : Report) : Report =
-        toList xs @ toList ys |> ofList
+    let tryRaise (report : Report) : unit =
+        match report.status with
+        | OK ->
+            ()
+        | GaveUp ->
+            raise <| GaveUpException (report.tests, report.discards)
+        | Failed (shrinks, journal)  ->
+            raise <| FailedException (report.tests, report.discards, shrinks, journal)
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Property =
-
-    let ofGen (x : Gen<Report * Result<'a>>) : Property<'a> =
+    let ofGen (x : Gen<Journal * Result<'a>>) : Property<'a> =
         Property x
 
-    let toGen (Property x : Property<'a>) : Gen<Report * Result<'a>> =
+    let toGen (Property x : Property<'a>) : Gen<Journal * Result<'a>> =
         x
 
+    let tryWith (m : Property<'a>) (k : exn -> Property<'a>) : Property<'a> =
+        Gen.tryWith (toGen m) (toGen << k) |> ofGen
+
+    let delay (f : unit -> Property<'a>) : Property<'a> =
+        Gen.delay (toGen << f) |> ofGen
+
+    let filter (p : 'a -> bool) (m : Property<'a>) : Property<'a> =
+        Gen.map (second <| Result.filter p) (toGen m) |> ofGen
+
     let ofResult (x : Result<'a>) : Property<'a> =
-        (Report.empty, x) |> Gen.constant |> ofGen
+        (Journal.empty, x) |> Gen.constant |> ofGen
 
     let failure : Property<unit> =
         Failure |> ofResult
@@ -101,7 +231,7 @@ module Property =
             failure
 
     let private mapGen
-            (f : Gen<Report * Result<'a>> -> Gen<Report * Result<'b>>)
+            (f : Gen<Journal * Result<'a>> -> Gen<Journal * Result<'b>>)
             (x : Property<'a>) : Property<'b> =
         toGen x |> f |> ofGen
 
@@ -109,19 +239,19 @@ module Property =
         (mapGen << Gen.map << second << Result.map) f x
 
     let counterexample (msg : string) (x : Property<'a>) : Property<'a> =
-        (mapGen << Gen.map << first << Report.addFailure) msg x
+        (mapGen << Gen.map << first << Journal.addFailure) msg x
 
     let private bindGen
-            (m : Gen<Report * Result<'a>>)
-            (k : 'a -> Gen<Report * Result<'b>>) : Gen<Report * Result<'b>> =
-        Gen.bind m <| fun (report, result) ->
+            (m : Gen<Journal * Result<'a>>)
+            (k : 'a -> Gen<Journal * Result<'b>>) : Gen<Journal * Result<'b>> =
+        Gen.bind m <| fun (journal, result) ->
             match result with
             | Failure ->
-                Gen.constant (report, Failure)
+                Gen.constant (journal, Failure)
             | Discard ->
-                Gen.constant (report, Discard)
+                Gen.constant (journal, Discard)
             | Success x ->
-                Gen.map (first (Report.append report)) (k x)
+                Gen.map (first (Journal.append journal)) (k x)
 
     let bind (m : Property<'a>) (k : 'a -> Property<'b>) : Property<'b> =
         bindGen (toGen m) (toGen << k) |> ofGen
@@ -136,43 +266,21 @@ module Property =
     //
 
     let rec private takeSmallest
-            (Node ((report, x), xs) : Tree<Report * Result<'a>>)
-            (nshrinks : int) : Option<Report * int> =
+            (Node ((journal, x), xs) : Tree<Journal * Result<'a>>)
+            (nshrinks : int<shrinks>) : Status =
         match x with
         | Failure ->
             match LazyList.tryFind (Result.isFailure << snd << Tree.outcome) xs with
             | None ->
-                Some (report, nshrinks)
+                Failed (nshrinks, journal)
             | Some tree ->
-                takeSmallest tree (nshrinks + 1)
+                takeSmallest tree (nshrinks + 1<shrinks>)
         | Discard ->
-            None
+            GaveUp
         | Success _ ->
-            None
+            OK
 
-    let private renderTests : int -> string = function
-        | 1 ->
-            "1 test"
-        | n ->
-            sprintf "%d tests" n
-
-    let private renderShrinks : int -> string = function
-        | 0 ->
-            ""
-        | 1 ->
-            " and 1 shrink"
-        | n ->
-            sprintf " and %d shrinks" n
-
-    let private renderDiscards : int -> string = function
-        | 0 ->
-            ""
-        | 1 ->
-            " and 1 discard"
-        | n ->
-            sprintf " and %d discards" n
-
-    let check' (n : int) (p : Property<unit>) : bool =
+    let report' (n : int<tests>) (p : Property<unit>) : Report =
         let random = toGen p |> Gen.toRandom
 
         let nextSize size =
@@ -183,36 +291,50 @@ module Property =
 
         let rec loop seed size tests discards =
             if tests = n then
-                tests, discards, Tree.singleton (Report.empty, Success ())
+                { tests = tests
+                  discards = discards
+                  status = OK }
+            elif discards >= 100<discards> then
+                { tests = tests
+                  discards = discards
+                  status = GaveUp }
             else
                 let seed1, seed2 = Seed.split seed
                 let result = Random.run seed1 size random
 
                 match snd (Tree.outcome result) with
                 | Failure ->
-                    tests + 1, discards, result
+                    { tests = tests + 1<tests>
+                      discards = discards
+                      status = takeSmallest result 0<shrinks> }
                 | Success () ->
-                    loop seed2 (nextSize size) (tests + 1) discards
+                    loop seed2 (nextSize size) (tests + 1<tests>) discards
                 | Discard ->
-                    loop seed2 size tests (discards + 1)
+                    loop seed2 size tests (discards + 1<discards>)
 
         let seed = Seed.random ()
-        let tests, discards, result = loop seed 1 0 0
+        loop seed 1 0<tests> 0<discards>
 
-        match takeSmallest result 0 with
-        | None ->
-            printfn "+++ OK, passed %s." (renderTests tests)
-            true
-        | Some (report, nshrinks) ->
-            printfn "*** Failed! Falsifiable (after %s%s%s):"
-                (renderTests tests)
-                (renderShrinks nshrinks)
-                (renderDiscards discards)
-            List.iter (printfn "%s") (Report.toList report)
-            false
+    let report (p : Property<unit>) : Report =
+        report' 100<tests> p
 
-    let check (p : Property<unit>) : bool =
-        check' 100 p
+    let check' (n : int<tests>) (p : Property<unit>) : unit =
+        report' n p
+        |> Report.tryRaise
+
+    let check (p : Property<unit>) : unit =
+        report p
+        |> Report.tryRaise
+
+    let print' (n : int<tests>) (p : Property<unit>) : unit =
+        report' n p
+        |> Report.render
+        |> printfn "%s"
+
+    let print (p : Property<unit>) : unit =
+        report p
+        |> Report.render
+        |> printfn "%s"
 
 [<AutoOpen>]
 module PropertyBuilder =
@@ -221,8 +343,21 @@ module PropertyBuilder =
         member __.For(m : Property<'a>, k : 'a -> Property<'b>) : Property<'b> =
             Property.bind m k
 
+        member __.For(xs : seq<'a>, k : 'a -> Property<unit>) : Property<unit> =
+            let join m n =
+                Property.bind m (fun _ -> n)
+            let init =
+                Property.success ()
+            xs |> Seq.map k |> Seq.fold join init
+
         member __.Yield(x : 'a) : Property<'a> =
             Property.success x
+
+        member __.Combine(m : Property<unit>, n : Property<'a>) : Property<'a> =
+            Property.bind m (fun _ -> n)
+
+        member __.TryWith(m : Property<'a>, k : exn -> Property<'a>) : Property<'a> =
+            Property.tryWith m k
 
         member __.Bind(m : Gen<'a>, k : 'a -> Property<'b>) : Property<'b> =
             Property.forAll m k
@@ -230,19 +365,22 @@ module PropertyBuilder =
         member __.Return(b : bool) : Property<unit> =
             Property.ofBool b
 
+        member __.ReturnFrom(m : Property<'a>) : Property<'a> =
+            m
+
         member __.Delay(f : unit -> Property<'a>) : Property<'a> =
-            Gen.delay (Property.toGen << f) |> Property.ofGen
+            Property.delay f
 
         member __.Zero() : Property<unit> =
-            Property.discard
+            Property.success ()
 
         [<CustomOperation("counterexample", MaintainsVariableSpace = true)>]
-        member __.Counterexample(g : Property<'a>, [<ProjectionParameter>] f : 'a -> string) : Property<'a> =
-            Property.bind g <| fun x ->
+        member __.Counterexample(m : Property<'a>, [<ProjectionParameter>] f : 'a -> string) : Property<'a> =
+            Property.bind m <| fun x ->
                 Property.counterexample (f x) (Property.success x)
 
         [<CustomOperation("where", MaintainsVariableSpace = true)>]
-        member __.Where(g : Property<'a>, [<ProjectionParameter>] p : 'a -> bool) : Property<'a> =
-            Gen.map (second <| Result.filter p) (Property.toGen g) |> Property.ofGen
+        member __.Where(m : Property<'a>, [<ProjectionParameter>] p : 'a -> bool) : Property<'a> =
+            Property.filter p m
 
     let property = Builder ()

--- a/Jack/Random.fs
+++ b/Jack/Random.fs
@@ -22,6 +22,13 @@ module Random =
         Random <| fun seed size ->
             unsafeRun seed size (g.Force())
 
+    let tryWith (r : Random<'a>) (k : exn -> Random<'a>) : Random<'a> =
+        Random <| fun seed size ->
+            try
+                unsafeRun seed size r
+            with
+                x -> unsafeRun seed size (k x)
+
     let constant (x : 'a) : Random<'a> =
         Random <| fun _ _ ->
             x

--- a/Jack/Script.fsx
+++ b/Jack/Script.fsx
@@ -16,14 +16,14 @@ open System
 // Combinators
 //
 
-Property.check <| property {
+Property.print <| property {
     let! x = Gen.range 1 100
     let! ys = Gen.item ["a"; "b"; "c"; "d"] |> Gen.seq
     counterexample (sprintf "tryHead ys = %A" <| Seq.tryHead ys)
     return x < 25 || Seq.length ys <= 3 || Seq.contains "a" ys
 }
 
-Property.check <| property {
+Property.print <| property {
     let! xs = Gen.string
     return String.length xs <= 5
 }
@@ -58,7 +58,7 @@ let rec genExp =
         Add <!> Gen.zip genExp genExp
     ]
 
-Property.check <| property {
+Property.print <| property {
     let! x = genExp
     match x with
     | Add (Add _, Add _) when evalExp x > 100 ->
@@ -71,7 +71,7 @@ Property.check <| property {
 // reverse (reverse xs) = xs, ∀xs :: [α] ― The standard "hello-world" property.
 //
 
-Property.check <| property {
+Property.print <| property {
     let! xs = Gen.list Gen.int
     return xs
             |> List.rev
@@ -93,7 +93,7 @@ Gen.printSample genLeapYear
 //
 
 // Fails due to integer overflow
-Property.check <| property {
+Property.print <| property {
     let! x = Gen.int
     let! y = Gen.int
     where (x > 0 && y > 0)
@@ -105,7 +105,7 @@ Property.check <| property {
 // Lazy Properties
 //
 
-Property.check <| property {
+Property.print <| property {
     let! n = Gen.int
     where (n <> 0)
     return 1 / n = 1 / n

--- a/Jack/Tree.fs
+++ b/Jack/Tree.fs
@@ -36,6 +36,13 @@ module Tree =
     let join (xss : Tree<Tree<'a>>) : Tree<'a> =
         bind xss id
 
+    /// Turns a tree, in to a tree of trees. Useful for testing Jack itself as
+    /// it allows you to observe the shrinks for a value inside a property,
+    /// while still allowing the property to shrink to a minimal
+    /// counterexample.
+    let rec duplicate (Node (_, ys) as x : Tree<'a>) : Tree<Tree<'a>> =
+        Node (x, LazyList.map duplicate ys)
+
     /// Fold over a tree.
     let rec fold (f : 'a -> 'x -> 'b) (g : LazyList<'b> -> 'x) (Node (x, xs) : Tree<'a>) : 'b =
         f x (foldForest f g xs)

--- a/Jack/paket.references
+++ b/Jack/paket.references
@@ -1,2 +1,2 @@
-FSharpPlus
+FsControl
 FSharpx.Collections

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ source https://www.nuget.org/api/v2/
 nuget FAKE 4.41.1
 nuget xunit.runner.console 2.1.0
 
-nuget FSharpPlus 1.0.0-CI00018
+nuget FsControl 2.0.0-CI00093
 nuget FSharpx.Collections 1.15.2
 
 nuget xunit.core 2.1.0

--- a/paket.lock
+++ b/paket.lock
@@ -4,8 +4,6 @@ NUGET
     FAKE (4.41.1)
     FsControl (2.0.0-CI00093)
     FSharp.Core (4.0.0.1)
-    FSharpPlus (1.0.0-CI00018)
-      FsControl (>= 2.0.0-CI00075)
     FSharpx.Collections (1.15.2)
       FSharp.Core
     Microsoft.NETCore.Platforms (1.0.1) - framework: dnxcore50


### PR DESCRIPTION
`Property.print`, and the lower level `Property.report`, are available for experimentation in scripts.

This PR has a number of changes:
- `Property.check` becomes `Property.report` and returns a rich data type instead of a `bool`
- `Property.print` gives more or less the same behaviour as the previous `Property.check` although it doesn't return a `bool`, maybe it should
- `Property.check` throws the new exceptions `GaveUpException` and `FailedException` where appropriate, this allows for better integration with test runners, as per issue #34 
- Added `MinimalTests.fs` to check that shrinking gives a minimal counterexample and to check that the test runner integration works well
- Added some more operations to the `property` builder, you can now loop over sequences, do arbitrary effects, and `try/catch` inside properties. I have no examples of using this yet but I needed it for some model testing stuff I was working on.

*edit: I also removed the dependency on FSharpPlus as we were only using FsControl, it might be nice if we can take the bits we need (to/from bigint) from FsControl so we don't need to depend on it either*