### PR TITLE
Apply the Apache License

### DIFF
--- a/Jack/LICENSE
+++ b/Jack/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2016 Jacob Stanley
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Jacob Stanley
+Copyright (c) 2016 Jacob Stanley, Nikos Baxevanis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
As discussed in #51, by attaching the boilerplate notice at http://www.apache.org/licenses/LICENSE-2.0/.