### PR TITLE
Add a 'Limitations' section to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,17 @@ There isn't much here yet, but `dotnet-jack` can be published on NuGet once it's
 
 `dotnet-jack` follows [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html) once it’s in a usable state.
 
+## Limitations
+
+Some of the features you'd expect from a property-based testing system are still missing, but we'll get there eventually:
+
+* Generating functions
+* Model-based testing
+
+Jack doesn't have an Arbitrary type class, by design. The main purpose of the Arbitrary class is to link the generator with a shrink function — this isn't required with Jack so Arbitrary has been eliminated.
+
+This library is still very new, and we wouldn't be surprised if some of the combinators are still a bit buggy.
+
 ## Credits
 
 The idea behind `dotnet-jack` originates from [`purescript-jack`](https://github.com/jystic/purescript-jack/) in PureScript and [`disorder-jack`](https://github.com/ambiata/disorder.hs/tree/master/disorder-jack/) in Haskell.


### PR DESCRIPTION
This is mostly a copy and paste from purescript-jack's *Limitations* section on the [README.md](https://github.com/jystic/purescript-jack/blob/5d5050361633b75f6e75632d6676b4fd27b39116/README.md).